### PR TITLE
Various changes, including removal of hard-coded "xerocraft" references.

### DIFF
--- a/abutils/utils.py
+++ b/abutils/utils.py
@@ -1,8 +1,10 @@
 # Standard
 import uuid
+import socket
 
 # Third Party
 from django.db.models import Model
+from django.http import HttpRequest
 
 # Local
 
@@ -23,3 +25,19 @@ def generate_ctrlid(model: Model) -> str:
     def is_unique(ctrlid: str) -> bool:
         return model.objects.filter(ctrlid=ctrlid).count() == 0
     return "GEN:" + generate_hex_string(8, is_unique)
+
+
+def get_ip_address(request: HttpRequest) -> str:
+    """ Get client machine's IP address from request """
+    x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
+    if x_forwarded_for:
+        ip = x_forwarded_for.split(',')[0]
+    else:
+        ip = request.META.get('REMOTE_ADDR')
+    return ip
+
+
+def request_is_from_host(request: HttpRequest, hostname: str) -> bool:
+    req_ip = get_ip_address(request)
+    host_ip = socket.gethostbyname(hostname)
+    return req_ip == host_ip

--- a/abutils/utils.py
+++ b/abutils/utils.py
@@ -23,7 +23,11 @@ def generate_ctrlid(model: Model) -> str:
     """Generate a unique ctrlid for the given model."""
     # TODO: Move this to ETL App if that refactorization is pursued.
     def is_unique(ctrlid: str) -> bool:
-        return model.objects.filter(ctrlid=ctrlid).count() == 0
+        if not hasattr(model, "ctrlid"):
+            # This is necessary to support initialization of new blank databases.
+            return True
+        else:
+            return model.objects.filter(ctrlid=ctrlid).count() == 0
     return "GEN:" + generate_hex_string(8, is_unique)
 
 

--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -15,24 +15,43 @@ class PermitRenewalInline(admin.TabularInline):
     model = PermitRenewal
     extra = 0
 
+    class Media:
+        css = {
+            "all": ("abutils/admin-tabular-inline.css",)
+        }
+
 
 class PermitScanInline(admin.TabularInline):
     model = PermitScan
     extra = 0
+    raw_id_fields = ['who']
+
+    class Media:
+        css = {
+            "all": ("abutils/admin-tabular-inline.css",)
+        }
 
 
 @admin.register(ParkingPermit)
 class ParkingPermitAdmin(VersionAdmin):
-    list_display = ['short_desc', 'owner', 'created', 'ok_to_move', 'is_in_inventoried_space']
+    list_display = ['pk', 'short_desc', 'owner', 'created', 'ok_to_move', 'is_in_inventoried_space']
     fields = ['short_desc', 'owner', 'created', 'ok_to_move', 'is_in_inventoried_space']
     readonly_fields = ['created']
     inlines = [PermitRenewalInline, PermitScanInline]
     raw_id_fields = ['owner']
 
+    search_fields = [
+        '^owner__auth_user__first_name',
+        '^owner__auth_user__last_name',
+        '^owner__auth_user__username',
+        '^owner__auth_user__email',
+    ]
+
 
 @admin.register(PermitScan)
 class PermitScanAdmin(VersionAdmin):
     list_display = ['pk', 'when', 'permit', 'where']
+    raw_id_fields = ['who']
 
 
 @admin.register(Location)

--- a/members/models.py
+++ b/members/models.py
@@ -413,7 +413,11 @@ class MemberLogin(models.Model):
 
 def next_paidmembership_ctrlid():
     '''Provides an arbitrary default value for the ctrlid field, necessary when check, cash, or gift-card data is being entered manually.'''
-    raise NotImplementedError("PaidMembership has been replaced iwth Membership.")
+
+    # Can't raise this exception while old migrations exist and blank dbs will be initialized by others.
+    #raise NotImplementedError("PaidMembership has been replaced iwth Membership.")
+
+    return generate_ctrlid(PaidMembership)
 
 
 class GroupMembership(models.Model):

--- a/members/notifications.py
+++ b/members/notifications.py
@@ -5,13 +5,22 @@ import logging
 
 # TODO: This was created before the "abutils" app. Move it there.
 
-pushover = chump.Application(os.environ['PUSHOVER_API_KEY'])
-assert pushover.is_authenticated
 logger = logging.getLogger("members")
+
+PUSHOVER_KEY = getattr(os.environ, 'PUSHOVER_API_KEY', None)
+if (PUSHOVER_KEY is not None):
+    pushover = chump.Application(os.environ['PUSHOVER_API_KEY'])
+    assert pushover.is_authenticated
+else:
+    pushover = None
+    logger.info("Pushover not configured. Alerts will not be sent.")
 
 
 # REVIEW: This sometimes fails. Should it be an asynchronous task with retries?
 def notify(target_member: Member, title: str, message: str):
+    if pushover is None:
+        return
+
     try:
         target_key = Pushover.objects.get(who=target_member).key
     except Pushover.DoesNotExist:

--- a/members/signals/handlers.py
+++ b/members/signals/handlers.py
@@ -11,6 +11,7 @@ from django.core.exceptions import ObjectDoesNotExist
 # Local
 from members.models import Member, Tag, Tagging, PaidMembership, MemberLogin, GroupMembership, Membership, VisitEvent
 import members.notifications as notifications
+from abutils.utils import get_ip_address
 
 __author__ = 'Adrian'
 
@@ -122,16 +123,6 @@ def link_membership_to_member(sender, **kwargs):
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # LOGIN
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-def get_ip_address(request):
-    """ Get client machine's IP address from request """
-    x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
-    if x_forwarded_for:
-        ip = x_forwarded_for.split(',')[0]
-    else:
-        ip = request.META.get('REMOTE_ADDR')
-    return ip
-
 
 @receiver(user_logged_in)
 def note_login(sender, user, request, **kwargs):  # https://code.djangoproject.com/ticket/22111

--- a/members/tests.py
+++ b/members/tests.py
@@ -165,7 +165,8 @@ class TestCardsAndApi(TestCase):
         path = "/members/api/visit-event/%s_%s/" % (self.str1, VisitEvent.EVT_ARRIVAL)
         response = c.get(path)
         json_response = json.loads(response.content.decode())
-        self.assertTrue(json_response['success'])
+        # This otherwise good test will fail because the test is run OUTSIDE the facility.
+        self.assertTrue(json_response['error'].startswith("Must be on"))  # Must be on {} WiFi to check in/out
 
     def test_visit_event_bad_evt_type(self):
         c = Client()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,11 +14,11 @@ freezegun==0.3.7
 gunicorn==19.3.0
 icalendar==3.9.1
 -e git+https://github.com/tgs/nptime.git@d8866bd76e0fcabc45674c69cee30380731d4acd#egg=nptime
-lxml==3.5.0
+lxml==3.6.1
 nameparser==0.3.11
 oauthlib==1.0.3
 Pillow==2.9.0
-psycopg2==2.6.1
+psycopg2==2.6.2
 pyflakes==1.1.0
 Pygments==2.0.2
 PyJWT==1.4.0

--- a/xerocraft/settings.py
+++ b/xerocraft/settings.py
@@ -326,4 +326,4 @@ INTSYS_ORG_NAME_POSSESSIVE = "Xerocraft's"
 # Set the INTSYS_FACILITY_PUBLIC_IP environment variable to either:
 #   (1) A DNS name that resolves to the facility's public IP
 #   (2) The facility's static IP address.
-INTSYS_FACILITY_PUBLIC_IP = getattr(os.environ, 'INTSYS_FACILITY_PUBLIC_IP', None)
+INTSYS_FACILITY_PUBLIC_IP = os.getenv('INTSYS_FACILITY_PUBLIC_IP', None)

--- a/xerocraft/settings.py
+++ b/xerocraft/settings.py
@@ -311,3 +311,19 @@ PYLINT_LOAD_PLUGIN = (
 )
 
 # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+# IntSys Config
+#
+# Using "IntSys" as a generic non-Xerocraft-specific name for the project.
+# The system is called "Xerocraft Internal Systems" (XIS) at Xerocraft.
+#
+# Configuration of IntSys for Xerocraft follows. Change for your organization.
+
+INTSYS_SYS_NAME = "XIS"
+
+INTSYS_ORG_NAME = "Xerocraft"
+INTSYS_ORG_NAME_POSSESSIVE = "Xerocraft's"
+
+# Set the FACILITY_PUBLIC_IP environment variable to either:
+#   (1) A DNS name that resolves to the facility's public IP
+#   (2) The facility's static IP address.
+INTSYS_FACILITY_PUBLIC_IP = getattr(os.environ, 'FACILITY_PUBLIC_IP', None)

--- a/xerocraft/settings.py
+++ b/xerocraft/settings.py
@@ -14,7 +14,10 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 import os
 
 import uuid
-DEVHOSTS = [238402988951122]
+DEVHOSTS = [
+    238402988951122,  # Adrian Linux
+    220083055528387,  # Adrian Mac
+]
 CURRHOST = uuid.getnode()
 ISDEVHOST = CURRHOST in DEVHOSTS
 

--- a/xerocraft/settings.py
+++ b/xerocraft/settings.py
@@ -323,7 +323,7 @@ INTSYS_SYS_NAME = "XIS"
 INTSYS_ORG_NAME = "Xerocraft"
 INTSYS_ORG_NAME_POSSESSIVE = "Xerocraft's"
 
-# Set the FACILITY_PUBLIC_IP environment variable to either:
+# Set the INTSYS_FACILITY_PUBLIC_IP environment variable to either:
 #   (1) A DNS name that resolves to the facility's public IP
 #   (2) The facility's static IP address.
-INTSYS_FACILITY_PUBLIC_IP = getattr(os.environ, 'FACILITY_PUBLIC_IP', None)
+INTSYS_FACILITY_PUBLIC_IP = getattr(os.environ, 'INTSYS_FACILITY_PUBLIC_IP', None)

--- a/xerocraft/settings.py
+++ b/xerocraft/settings.py
@@ -62,16 +62,17 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 # Social auth would work inside AND outside if we replace reverse proxy inside XC with Heroku's SSL.
 # That said, I'm not sure that access outside Xerocraft should be allowed at all.
 # BTW, one Stack Exchange comment blames Heroku: "This is because heroku fails to pass the headers"
-SOCIAL_AUTH_REDIRECT_IS_HTTPS = True
 
-SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.environ['GOOGLE_OAUTH2_KEY']
-SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.environ['GOOGLE_OAUTH2_SECRET']
+# SOCIAL_AUTH_REDIRECT_IS_HTTPS = True
 
-SOCIAL_AUTH_TWITTER_KEY = os.environ['TWITTER_KEY']
-SOCIAL_AUTH_TWITTER_SECRET = os.environ['TWITTER_SECRET']
+# SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.environ['GOOGLE_OAUTH2_KEY']
+# SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.environ['GOOGLE_OAUTH2_SECRET']
 
-SOCIAL_AUTH_FACEBOOK_KEY =  os.environ['FACEBOOK_KEY']
-SOCIAL_AUTH_FACEBOOK_SECRET =  os.environ['FACEBOOK_SECRET']
+# SOCIAL_AUTH_TWITTER_KEY = os.environ['TWITTER_KEY']
+# SOCIAL_AUTH_TWITTER_SECRET = os.environ['TWITTER_SECRET']
+
+# SOCIAL_AUTH_FACEBOOK_KEY =  os.environ['FACEBOOK_KEY']
+# SOCIAL_AUTH_FACEBOOK_SECRET =  os.environ['FACEBOOK_SECRET']
 
 # Application definition
 INSTALLED_APPS = (
@@ -127,9 +128,9 @@ SESSION_SAVE_EVERY_REQUEST = True
 AUTHENTICATION_BACKENDS = (
     'xerocraft.authenticators.CaseInsensitiveModelBackend',
     'xerocraft.authenticators.XerocraftBackend',
-    'social.backends.facebook.FacebookOAuth2',
-    'social.backends.google.GoogleOAuth2',
-    'social.backends.twitter.TwitterOAuth',
+    # 'social.backends.facebook.FacebookOAuth2',
+    # 'social.backends.google.GoogleOAuth2',
+    # 'social.backends.twitter.TwitterOAuth',
 )
 if ISDEVHOST:
     AUTHENTICATION_BACKENDS += (
@@ -158,8 +159,8 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'django.core.context_processors.request',
-                'social.apps.django_app.context_processors.backends',
-                'social.apps.django_app.context_processors.login_redirect',
+                # 'social.apps.django_app.context_processors.backends',
+                # 'social.apps.django_app.context_processors.login_redirect',
             ],
         },
     },


### PR DESCRIPTION
As we discussed, you'll see the introduction of some INTSYS_ settings in xerocraft/settings.py. For example, INTSYS_ORGNAME is set to "Xerocraft" in my settings.py but should be set to "Cirque Roots" in yours. 

You can see some of these settings being used in members.views.api_log_visit_event. This is an API that's currently used by iOS and Android apps to allow members to check in/out from their phone, but it should only allow check in/out if the member is at the organization's facility (i.e. place of business). It checks by looking at the public IP address of the facility, which will be different for each organization, hence INTSYS_FACILITY_PUBLIC_IP in settings.py.
